### PR TITLE
Enhance idle mode

### DIFF
--- a/src/mac/mac_bs.c
+++ b/src/mac/mac_bs.c
@@ -642,7 +642,8 @@ void mac_bs_run_scheduler(MacBS mac) {
   }
 
   // 4. set slot assignments in PHY
-  phy_assign_dlctrl_dd(mac->phy, mac->dl_data_assignments[next_sfn]);
+  phy_assign_dlctrl_dd(mac->phy, next_sfn % 2,
+                       mac->dl_data_assignments[next_sfn]);
   phy_assign_dlctrl_ud(mac->phy, next_sfn % 2,
                        mac->ul_data_assignments[next_sfn]);
   phy_assign_dlctrl_uc(mac->phy, next_sfn % 2,

--- a/src/phy/phy_bs.c
+++ b/src/phy/phy_bs.c
@@ -70,6 +70,12 @@ PhyBS phy_bs_init() {
   phy->ul_symbol_alloc[0] = calloc(sizeof(uint8_t) * SUBFRAME_LEN, 1);
   phy->ul_symbol_alloc[1] = calloc(sizeof(uint8_t) * SUBFRAME_LEN, 1);
 
+  phy->dl_symbol_alloc = malloc(sizeof(uint8_t *) * 2);
+  phy->dl_symbol_alloc[0] = calloc(SUBFRAME_LEN, 1);
+  phy->dl_symbol_alloc[1] = calloc(SUBFRAME_LEN, 1);
+  memset(phy->dl_symbol_alloc[0], DATA, DLCTRL_LEN);
+  memset(phy->dl_symbol_alloc[1], DATA, DLCTRL_LEN);
+
   // allocate memory for rach_buffer
   phy->rach_buffer = calloc(sizeof(float complex) * nfft, 1);
 
@@ -270,11 +276,20 @@ void phy_map_dlctrl(PhyBS phy, uint subframe) {
 }
 
 // Set the assignments of Downlink data slots
-void phy_assign_dlctrl_dd(PhyBS phy, uint8_t *slot_assignment) {
+void phy_assign_dlctrl_dd(PhyBS phy, uint subframe, uint8_t *slot_assignment) {
   for (int i = 0; i < NUM_SLOT; i += 2) {
     phy->dlctrl_buf[i / 2].h4 = slot_assignment[i];
     phy->dlctrl_buf[i / 2].l4 = slot_assignment[i + 1];
   }
+  // set allocation with ofdm symbol granularity.
+  memset(&phy->dl_symbol_alloc[subframe][4],
+         slot_assignment[0] == 0 ? NOT_USED : DATA, SLOT_LEN);
+  memset(&phy->dl_symbol_alloc[subframe][4 + SLOT_LEN + 1],
+         slot_assignment[1] == 0 ? NOT_USED : DATA, SLOT_LEN);
+  memset(&phy->dl_symbol_alloc[subframe][4 + 2 * (SLOT_LEN + 1)],
+         slot_assignment[2] == 0 ? NOT_USED : DATA, SLOT_LEN);
+  memset(&phy->dl_symbol_alloc[subframe][4 + 3 * (SLOT_LEN + 1)],
+         slot_assignment[3] == 0 ? NOT_USED : DATA, SLOT_LEN);
 }
 
 // Set the assignments of Uplink data slots
@@ -558,12 +573,16 @@ void phy_bs_write_symbol(PhyBS phy, float complex *txbuf_time) {
   } else if (common->tx_subframe == 0 &&
              tx_symb == SUBFRAME_LEN - 1 - SYNC_SYMBOLS + 3) {
     phy_bs_write_sync_info(phy, txbuf_time);
-  } else if (common->pilot_symbols_tx[tx_symb] == NO_PILOT) {
-    ofdmframegen_writesymbol_nopilot(phy->fg, common->txdata_f[sfn][tx_symb],
-                                     txbuf_time);
+  } else if (phy->dl_symbol_alloc[sfn][tx_symb] == DATA) {
+    if (common->pilot_symbols_tx[tx_symb] == NO_PILOT) {
+      ofdmframegen_writesymbol_nopilot(phy->fg, common->txdata_f[sfn][tx_symb],
+                                       txbuf_time);
+    } else {
+      ofdmframegen_writesymbol(phy->fg, common->txdata_f[sfn][tx_symb],
+                               txbuf_time);
+    }
   } else {
-    ofdmframegen_writesymbol(phy->fg, common->txdata_f[sfn][tx_symb],
-                             txbuf_time);
+    memset(txbuf_time, 0, sizeof(float complex) * (nfft + cp_len));
   }
 
   // clear frequency domain memory of the written symbol, to avoid sending

--- a/src/phy/phy_bs.h
+++ b/src/phy/phy_bs.h
@@ -40,11 +40,12 @@ struct PhyBS_s {
   uint8_t **ulslot_assignments;
   uint8_t **ulctrl_assignments;
 
-  // store uplink resource allocation on OFDM symbol basis
+  // store resource allocation on OFDM symbol basis
   // BS has to pick the correct ofdmframesync object depending on the user
   // 1. Index: subframe index: 0 -> even, 1->odd
   // 2. Index ofdm symbol idx
   uint8_t **ul_symbol_alloc;
+  uint8_t **dl_symbol_alloc;
 
   dlctrl_alloc_t *dlctrl_buf; // holds DL ctrl slot data
 
@@ -81,7 +82,7 @@ void phy_bs_set_rx_slot_th_signal(PhyBS phy, pthread_cond_t *cond);
 int phy_map_dlslot(PhyBS phy, LogicalChannel chan, uint subframe,
                    uint8_t slot_nr, uint userid, uint mcs);
 void phy_map_dlctrl(PhyBS phy, uint subframe);
-void phy_assign_dlctrl_dd(PhyBS phy, uint8_t *slot_assignment);
+void phy_assign_dlctrl_dd(PhyBS phy, uint subframe, uint8_t *slot_assignment);
 void phy_assign_dlctrl_ud(PhyBS phy, uint subframe, uint8_t *slot_assignment);
 void phy_assign_dlctrl_uc(PhyBS phy, uint subframe, uint8_t *slot_assignment);
 

--- a/src/phy/phy_common.c
+++ b/src/phy/phy_common.c
@@ -218,13 +218,16 @@ void gen_pilot_symbols(PhyCommon phy, uint is_bs) {
   memset(pilot_ul, NO_PILOT, SUBFRAME_LEN);
 
   // DL: dlctrl slot uses pilots
-  memset(&pilot_dl[0], PILOT, DLCTRL_LEN);
+  pilot_dl[0] = PILOT_RESET;
+  pilot_dl[1] = PILOT;
 
   // replicate slot allocation for one slot over the subframe
   for (int slot_nr = 0; slot_nr < NUM_SLOT; slot_nr++) {
     int slot_start = DLCTRL_LEN + 2 * SLOT_GUARD_INTERVAL +
                      slot_nr * (SLOT_LEN + SLOT_GUARD_INTERVAL);
     memcpy(&pilot_dl[slot_start], pilot_symbols, SLOT_LEN);
+    pilot_dl[slot_start] = PILOT_RESET; // force first symbol of the slot to
+                                        // contain the pilot sequence reset flag
   }
 
   // Pilot symbols within subframe in UL
@@ -236,7 +239,15 @@ void gen_pilot_symbols(PhyCommon phy, uint is_bs) {
   memcpy(&pilot_ul[3 * (SLOT_LEN + SLOT_GUARD_INTERVAL) + NUM_ULCTRL_SLOT * 2],
          pilot_symbols, SLOT_LEN);
 
+  // force first symbol of the slot to contain the pilot sequence reset flag
+  pilot_ul[0] = PILOT_RESET;
+  pilot_ul[SLOT_LEN + SLOT_GUARD_INTERVAL] = PILOT_RESET;
+  pilot_ul[2 * (SLOT_LEN + SLOT_GUARD_INTERVAL) + NUM_ULCTRL_SLOT * 2] =
+      PILOT_RESET;
+  pilot_ul[3 * (SLOT_LEN + SLOT_GUARD_INTERVAL) + NUM_ULCTRL_SLOT * 2] =
+      PILOT_RESET;
+
   // ulctrl slots
-  pilot_ul[2 * (SLOT_LEN + SLOT_GUARD_INTERVAL)] = PILOT;
-  pilot_ul[2 * (SLOT_LEN + SLOT_GUARD_INTERVAL) + 2] = PILOT;
+  pilot_ul[2 * (SLOT_LEN + SLOT_GUARD_INTERVAL)] = PILOT_RESET;
+  pilot_ul[2 * (SLOT_LEN + SLOT_GUARD_INTERVAL) + 2] = PILOT_RESET;
 }

--- a/src/phy/phy_config.c
+++ b/src/phy/phy_config.c
@@ -22,6 +22,7 @@
 #include "../util/log.h"
 #include <libconfig.h>
 #include <liquid/liquid.h>
+#include <string.h>
 
 void phy_config_load_file(char *config_file) {
   config_t cfg;
@@ -134,7 +135,10 @@ void phy_config_default_64() {
   num_data_sc = 32;
   num_pilot_sc = 8;
   pilot_symbols_per_slot = 7;
-  pilot_symbols = calloc(SLOT_LEN, 1);
+
+  pilot_symbols = malloc(SLOT_LEN);
+  memset(pilot_symbols, NO_PILOT, SLOT_LEN);
+  pilot_symbols[0] = PILOT_RESET;
   for (int i = 0; i < SLOT_LEN; i += 2)
     pilot_symbols[i] = PILOT;
 

--- a/src/phy/phy_config.h
+++ b/src/phy/phy_config.h
@@ -76,8 +76,8 @@ enum {
   DATA,
   PTT_UP,
   PTT_DOWN
-};                        // definition for tx_symbol allocation variable
-enum { NO_PILOT, PILOT }; // definition for pilot_symbols variable
+}; // definition for tx_symbol allocation variable
+enum { NO_PILOT, PILOT, PILOT_RESET }; // definition for pilot_symbols variable
 
 // ---------------------------- global PHY layer configurtion
 // --------------------------------- //

--- a/src/phy/phy_ue.h
+++ b/src/phy/phy_ue.h
@@ -52,6 +52,7 @@ struct PhyUE_s {
   // 1. Index: subframe index: 0 -> even, 1->odd
   // 2. Index ofdm symbol idx
   uint8_t **ul_symbol_alloc;
+  uint8_t *dl_symbol_alloc;
 
   // Currently used modulation scheme for RX
   uint mcs_dl;

--- a/src/platform/pluto.c
+++ b/src/platform/pluto.c
@@ -431,7 +431,7 @@ void init_generic(platform hw, uint buf_len, char *config_file) {
   // Set RX AGC to slow attack
   get_phy_chan(pluto->ctx, RX, 0, &chn);
   wr_ch_str(chn, "gain_control_mode",
-            "slow_attack"); // fast_attack, slow_attack, manual
+            "fast_attack"); // fast_attack, slow_attack, manual
                             // wr_ch_lli(chn, "hardwaregain", 26.0);
 
   printf("* Enabling IIO streaming channels\n");

--- a/src/runtime/client.c
+++ b/src/runtime/client.c
@@ -236,9 +236,9 @@ void *thread_phy_ue_tx(void *arg) {
         num_samples = buflen - tx_shift;
 
         // set PTT signal delay
-        pluto_ptt_set_switch_delay(hw,
-                                   (int)((buflen * KERNEL_BUF_TX + tx_shift) *
-                                         1000000.0 / samplerate));
+        pluto_ptt_set_switch_delay(
+            hw, (int)((buflen * (KERNEL_BUF_TX - 1) + tx_shift) * 1000000.0 /
+                      samplerate));
       }
     }
   }


### PR DESCRIPTION
This PR will make the the DL channel way more silent and simplify the pilot tone generation. 

- Pilot tones are now generated via an msequence that is reset at the start of every slot. This is the same for UL and DL.
- Basestation will now remain silent when there is no data to transmit
- Initial gain control had to be changed, to work with the more silent BS. We use fast_attack mode during initial gain estimation.

**NOTE:** This PR makes the BS and Client software incompatible with previous versions! Pilot definitions changed and the client cannot expect that the BS is always transmitting anymore.

## Tests

Since we rely on manual testing, here is what tests will be performed:

- [x] Compile-able for _all_ targets
- [x] General operability of the simulation target. Client and BS can connect and transfer data.
- [x] Verify that the BER did not increase in simulation
- [x] General operability of the standalone targets. Client and BS can connect and transfer data.

Simulations in Rayleigh fading channel for downlink show a slight performance decrease. 
![downlink ber performance](https://user-images.githubusercontent.com/44869119/86395184-203ed780-bca0-11ea-8d16-39a925ba9850.png)

Simulations with static multipath in the uplink show that the BER performance is similar to the current version
![enhance_idle_ber_ul](https://user-images.githubusercontent.com/44869119/86467387-9b060200-bd35-11ea-9d38-5021fc2330a2.png)
