### PR TITLE
Include version info in executables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,27 @@ include_directories(src/platform)
 include_directories(src/runtime)
 include_directories(src/util)
 
+### Create version.h files to include version info in the executables
+# get branch
+execute_process(
+        COMMAND git rev-parse --abbrev-ref HEAD
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE GIT_BRANCH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+# get latest tag and commit hash
+execute_process(
+        COMMAND git describe --tags
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE GIT_TAG
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+message(STATUS "Git current branch: ${GIT_BRANCH}")
+message(STATUS "Git tag: ${GIT_TAG}")
+message(STATUS "Generating version.h")
+configure_file(src/runtime/version.h.in version.h)
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 ### Group source files to PHY and MAC layer for UE/BS respectively
 

--- a/src/runtime/basestation.c
+++ b/src/runtime/basestation.c
@@ -26,6 +26,7 @@
 #include "../platform/platform_simulation.h"
 #include "../platform/pluto.h"
 #include "../util/log.h"
+#include "version.h"
 
 #include <getopt.h>
 #include <pthread.h>
@@ -64,6 +65,7 @@ struct option Options[] = {
     {"config", required_argument, NULL, 'c'},
     {"log", required_argument, NULL, 'l'},
     {"help", no_argument, NULL, 'h'},
+    {"version", no_argument, NULL, 'v'},
     {NULL},
 };
 char *helpstring = "Basestation for 70cm Waveform.\n\n \
@@ -73,7 +75,8 @@ Options:\n \
    --frequency -f: tune to a specific (DL) frequency\n \
    --config -c     specify a configuration file\n \
    --log -l        specify the log level. Default: 2.\n \
-                   0=TRACE 1=DEBUG 2=INFO 3=WARN 4=ERR 5=NONE\n";
+                   0=TRACE 1=DEBUG 2=INFO 3=WARN 4=ERR 5=NONE\n \
+   --version -v    show version info";
 
 extern char *optarg;
 int rxgain = 70;
@@ -253,7 +256,7 @@ int main(int argc, char *argv[]) {
 
   // parse program args
   int d;
-  while ((d = getopt_long(argc, argv, "g:t:f:c:l:h", Options, NULL)) != EOF) {
+  while ((d = getopt_long(argc, argv, "g:t:f:c:l:v:h", Options, NULL)) != EOF) {
     switch (d) {
     case 'g':
       rxgain = atoi(optarg);
@@ -286,6 +289,10 @@ int main(int argc, char *argv[]) {
       break;
     case 'h':
       printf("%s", helpstring);
+      exit(0);
+      break;
+    case 'v':
+      printf("Build version %s %s\n", GIT_TAG, GIT_BRANCH);
       exit(0);
       break;
     default:

--- a/src/runtime/client-calib.c
+++ b/src/runtime/client-calib.c
@@ -26,6 +26,7 @@
 #include "../platform/platform_simulation.h"
 #include "../platform/pluto.h"
 #include "../util/log.h"
+#include <version.h>
 
 #include <getopt.h>
 #include <math.h>
@@ -51,6 +52,7 @@ struct option Options[] = {
     {"config", required_argument, NULL, 'c'},
     {"log", required_argument, NULL, 'l'},
     {"help", no_argument, NULL, 'h'},
+    {"version", no_argument, NULL, 'v'},
     {NULL},
 };
 char *helpstring = "Estimate clock drift of the client.\n\n \
@@ -138,7 +140,7 @@ int main(int argc, char *argv[]) {
 
   // parse program args
   int d;
-  while ((d = getopt_long(argc, argv, "g:f:c:l:h", Options, NULL)) != EOF) {
+  while ((d = getopt_long(argc, argv, "g:f:c:l:v:h", Options, NULL)) != EOF) {
     switch (d) {
     case 'g':
       rxgain = atoi(optarg);
@@ -168,6 +170,10 @@ int main(int argc, char *argv[]) {
       break;
     case 'h':
       printf("%s", helpstring);
+      exit(0);
+      break;
+    case 'v':
+      printf("Build version %s %s\n", GIT_TAG, GIT_BRANCH);
       exit(0);
       break;
     default:

--- a/src/runtime/client.c
+++ b/src/runtime/client.c
@@ -26,6 +26,7 @@
 #include "../platform/platform_simulation.h"
 #include "../platform/pluto.h"
 #include "../util/log.h"
+#include <version.h>
 
 #include <getopt.h>
 #include <pthread.h>
@@ -61,6 +62,7 @@ struct option Options[] = {
     {"config", required_argument, NULL, 'c'},
     {"help", no_argument, NULL, 'h'},
     {"log", required_argument, NULL, 'l'},
+    {"version", no_argument, NULL, 'v'},
     {NULL},
 };
 char *helpstring = "Client for 70cm Waveform.\n\n \
@@ -72,7 +74,8 @@ Options:\n \
    --dl-mcs -d:    use given mcs in DL. Default: 0.\n \
    --config -c     specify a configuration file\n \
    --log -l        specify the log level. Default: 2.\n \
-                   0=TRACE 1=DEBUG 2=INFO 3=WARN 4=ERR 5=NONE\n";
+                   0=TRACE 1=DEBUG 2=INFO 3=WARN 4=ERR 5=NONE\n\
+   --version -v    show version info";
 
 extern char *optarg;
 int rxgain = -100;
@@ -372,7 +375,7 @@ int main(int argc, char *argv[]) {
 
   // parse program args
   int d;
-  while ((d = getopt_long(argc, argv, "g:t:f:d:u:c:l:h", Options, NULL)) !=
+  while ((d = getopt_long(argc, argv, "g:t:f:d:u:c:l:v:h", Options, NULL)) !=
          EOF) {
     switch (d) {
     case 'g':
@@ -422,6 +425,10 @@ int main(int argc, char *argv[]) {
       break;
     case 'h':
       printf("%s", helpstring);
+      exit(0);
+      break;
+    case 'v':
+      printf("Build version %s %s\n", GIT_TAG, GIT_BRANCH);
       exit(0);
       break;
     default:

--- a/src/runtime/test_cfo_estimation.c
+++ b/src/runtime/test_cfo_estimation.c
@@ -23,6 +23,7 @@
 #include "../phy/phy_bs.h"
 #include "../phy/phy_ue.h"
 #include "../platform/platform_simulation.h"
+#include <version.h>
 
 extern struct phy_config_s PHY_CONFIG;
 
@@ -110,6 +111,7 @@ int main(int argc, char *argv[]) {
 
   for (int cfo = 0; cfo < 1; cfo += 50) {
     for (int snr = 5; snr < 41; snr += 5) {
+      printf("Build version %s %s\n", GIT_TAG, GIT_BRANCH);
       printf("Starting simulation with SNR %ddB; cfo %dHz\n", snr, cfo);
 
       log_coarse_cfo_flag = 0;

--- a/src/runtime/test_mac.c
+++ b/src/runtime/test_mac.c
@@ -25,6 +25,7 @@
 #include "../platform/platform_simulation.h"
 
 #include "test.h"
+#include <version.h>
 
 // size of a mac data frame in bytes [VoIP data + UDP + IP + Ethernet header]
 #define payload_size (20 + 8 + 20 + 14)
@@ -296,6 +297,7 @@ int main(int argc, char *argv[]) {
   }
 
   for (int snr = 25; snr < 40; snr += 1) {
+    printf("Build version %s %s\n", GIT_TAG, GIT_BRANCH);
     printf("Starting simulation with SNR %ddB mcs%d\n", snr, mcs);
 
     setup_simulation(snr, cfo);

--- a/src/runtime/version.h.in
+++ b/src/runtime/version.h.in
@@ -1,0 +1,6 @@
+#ifndef VERSION_H
+#define VERSION_H
+
+#define GIT_BRANCH "@GIT_BRANCH@"
+#define GIT_TAG "@GIT_TAG@"
+#endif


### PR DESCRIPTION
We use cmake to run the corresponding git commands and create a version.h file that contains version makros.

The version is automatically printed for the simulation target. For the standalone targets it can be displayed by passing the `-v` parameter.

Example output:

>Build version v1.0.0-7-g9f04dd2 include_version_info

7 commits ahead of v.1.0.0, latest commit hash is 9f04dd2, branch include_version_info