### PR TITLE
LLDP: transmit firmware and HNAP version (#5)

### DIFF
--- a/startup_scripts/S60lldpd
+++ b/startup_scripts/S60lldpd
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# Controls lldpd.
+#
+
+case $1 in
+    start)
+	printf "Starting lldpd: "
+	start-stop-daemon -S -q -p /var/run/lldpd.pid --exec /usr/sbin/lldpd -- -cc
+	[ $? = 0 ] && echo "OK" || echo "FAIL"
+	;;
+    stop)
+	printf "Stopping lldpd: "
+	start-stop-daemon -K -q -p /var/run/lldpd.pid
+	[ $? = 0 ] && echo "OK" || echo "FAIL"
+	;;
+    restart)
+	$0 stop
+	$0 start
+	;;
+    *)
+	echo "Usage: $0 {start|stop|restart}"
+	exit 1
+	;;
+esac

--- a/startup_scripts/S90transceiver.sh
+++ b/startup_scripts/S90transceiver.sh
@@ -9,11 +9,11 @@ FILTER=AD9361_256kSPS.ftr
 # This has to be done after lldp is started (S60)
 CALLSIGN=$(fw_printenv -n hnap_callsign)
 PLATFORM_STRING=$(grep plutosdr-fw /root/VERSION)
-DESC_STRING="$CALLSIGN $(grep hnap /root/VERSION | cut -c6-)"
+DESC_STRING="$(grep hnap /root/VERSION) $PLATFORM_STRING"
 
 lldpcli configure lldp tx-interval 60
-lldpcli configure system hostname "$PLATFORM_STRING"
-lldpcli configure system description "$DESC_STRING"
+lldpcli configure system hostname "$CALLSIGN"
+lldpcli configure system platform "$DESC_STRING"
 lldpcli resume
 
 # Install custom FIR filter

--- a/startup_scripts/S90transceiver.sh
+++ b/startup_scripts/S90transceiver.sh
@@ -12,7 +12,7 @@ PLATFORM_STRING=$(grep plutosdr-fw /root/VERSION)
 DESC_STRING="$CALLSIGN $(grep hnap /root/VERSION | cut -c6-)"
 
 lldpcli configure lldp tx-interval 60
-lldpcli configure system platform "$PLATFORM_STRING"
+lldpcli configure system hostname "$PLATFORM_STRING"
 lldpcli configure system description "$DESC_STRING"
 lldpcli resume
 

--- a/startup_scripts/S90transceiver.sh
+++ b/startup_scripts/S90transceiver.sh
@@ -7,9 +7,13 @@ FILTER=AD9361_256kSPS.ftr
 
 # Config Link Layer Discovery Protocol to broadcast callsign
 # This has to be done after lldp is started (S60)
-CALLSIGN=`fw_printenv -n hnap_callsign`
+CALLSIGN=$(fw_printenv -n hnap_callsign)
+PLATFORM_STRING=$(grep plutosdr-fw /root/VERSION)
+DESC_STRING="$CALLSIGN $(grep hnap /root/VERSION | cut -c6-)"
+
 lldpcli configure lldp tx-interval 60
-lldpcli configure system description $CALLSIGN
+lldpcli configure system platform "$PLATFORM_STRING"
+lldpcli configure system description "$DESC_STRING"
 lldpcli resume
 
 # Install custom FIR filter


### PR DESCRIPTION
Configure the LLDP daemon to transmit the plutosdr-fw and the HNAP4Plutosdr version.
lldpd config is now as follows:

**NOTE:** instead of the proposed _system platform_ configuration parameter, _system hostname_ is used to broadcast the firmware name and version. _system platform_ parameter is only used when Cisco Discovery Protocol (CDP) is activated, we currently use LLDP.
```
# lldpcli show config
-------------------------------------------------------------------------------
Global configuration:
-------------------------------------------------------------------------------
Configuration:
  Transmit delay: 60
  Transmit hold: 4
  Receive mode: no
  Pattern for management addresses: (none)
  Interface pattern: (none)
  Permanent interface pattern: (none)
  Interface pattern for chassis ID: (none)
  Override chassis ID with: (none)
  Override description with: CALLSIGN v1.0.0-17-g181cb05
  Override platform with: Linux
  Override system name with: plutosdr-fw v0.32
  Advertise version: yes
  Update interface descriptions: no
  Promiscuous mode on managed interfaces: no
  Disable LLDP-MED inventory: yes
  LLDP-MED fast start mechanism: yes
  LLDP-MED fast start interval: 1
  Source MAC for LLDP frames on bond slaves: local
  Port ID TLV subtype for LLDP frames: unknown
  Agent type:   unknown
```

Closes #5 