### PR TITLE
Update .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,4 +4,4 @@ repos:
       hooks:
           - id: clang-format
             args: [-i]
-            files: 'src/.*\.[ch]'
+            files: '[src,tests]/.*\.[ch]'


### PR DESCRIPTION
Targets #35 ... tested locally. Linting is only done on the contents of src and tests, not recursively (tests/unity is ignored).