### PR TITLE
Fix ptt_delay_comp variable name in config.txt

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -52,8 +52,9 @@ phy:
 # Platform configuration
 platform:
 {
-  tx_bandwdith = 1701126;   # Passband of the analog TX filter.
+  tx_bandwidth = 1701126;   # Passband of the analog TX filter.
   rx_bandwidth = 1703632;   # Passband of the analog RX filter.
+  enable_ptt = 0;           # Enable output of PTT signal on MIO0 pin
   ptt_delay_comp = 200;     # Adjust the timing of the PTT signal in usec
 }
 

--- a/config.txt
+++ b/config.txt
@@ -54,7 +54,7 @@ platform:
 {
   tx_bandwdith = 1701126;   # Passband of the analog TX filter.
   rx_bandwidth = 1703632;   # Passband of the analog RX filter.
-  ptt_delay_comp_us = 200;  # Adjust the timing of the PTT signal in usec
+  ptt_delay_comp = 200;     # Adjust the timing of the PTT signal in usec
 }
 
 

--- a/src/platform/pluto.c
+++ b/src/platform/pluto.c
@@ -364,9 +364,9 @@ void init_generic(platform hw, uint buf_len, char *config_file) {
     }
     platform_settings = config_lookup(&cfg, "platform");
     if (platform_settings != NULL) {
-      config_setting_lookup_int64(platform_settings, "tx_bandwdith",
+      config_setting_lookup_int64(platform_settings, "tx_bandwidth",
                                   &pluto->txcfg.bw_hz);
-      config_setting_lookup_int64(platform_settings, "rx_bandwdith",
+      config_setting_lookup_int64(platform_settings, "rx_bandwidth",
                                   &pluto->rxcfg.bw_hz);
       config_setting_lookup_int(platform_settings, "enable_ptt",
                                 &pluto->enable_ptt);


### PR DESCRIPTION
The parser in init_generic() in file platform/pluto.c searches for this variable name: https://github.com/HAMNET-Access-Protocol/HNAP4PlutoSDR/blob/89737d8d3638f2da49ffc8c04a572384158d4aca/src/platform/pluto.c#L373

Thanks to @silencer79 who found this.