### PR TITLE
Fix frequency correction for client uplink

### DIFF
--- a/src/runtime/client.c
+++ b/src/runtime/client.c
@@ -351,11 +351,13 @@ void phy_carrier_sync(PhyUE phy, platform hw) {
   pluto_set_txgain(hw, txgain);
 
   // tune to the correct frequency
-  pluto_set_tx_freq(hw, ul_lo + (long)cfo_hz);
-  pluto_set_rx_freq(hw, dl_lo + (long)cfo_hz);
+  pluto_set_tx_freq(hw,
+                    ul_lo + (long long)(cfo_hz * (float)ul_lo / (float)dl_lo));
+  pluto_set_rx_freq(hw, dl_lo + (long long)cfo_hz);
   LOG(INFO, "[CLIENT] retune transceiver with cfo %.3fHz:\n", cfo_hz);
-  LOG(INFO, "[CLIENT] TX LO freq: %lldHz\n", ul_lo + (long)cfo_hz);
-  LOG(INFO, "[CLIENT] RX LO freq: %lldHz\n", dl_lo + (long)cfo_hz);
+  LOG(INFO, "[CLIENT] TX LO freq: %lldHz\n",
+      ul_lo + (long long)(cfo_hz * (float)ul_lo / (float)dl_lo));
+  LOG(INFO, "[CLIENT] RX LO freq: %lldHz\n", dl_lo + (long long)cfo_hz);
   LOG(INFO, "[CLIENT] rxgain adjusted: %d\n", rxgain);
   LOG(INFO, "[CLIENT] txgain adjusted: %d\n", txgain);
   free(rxbuf_time);

--- a/src/runtime/client.c
+++ b/src/runtime/client.c
@@ -351,13 +351,14 @@ void phy_carrier_sync(PhyUE phy, platform hw) {
   pluto_set_txgain(hw, txgain);
 
   // tune to the correct frequency
-  pluto_set_tx_freq(hw,
-                    ul_lo + (long long)(cfo_hz * (float)ul_lo / (float)dl_lo));
-  pluto_set_rx_freq(hw, dl_lo + (long long)cfo_hz);
+  long long int ul_lo_fixed =
+      ul_lo + (long long)(cfo_hz * (float)ul_lo / (float)dl_lo);
+  long long int dl_lo_fixed = dl_lo + (long long)cfo_hz;
+  pluto_set_tx_freq(hw, ul_lo_fixed);
+  pluto_set_rx_freq(hw, dl_lo_fixed);
   LOG(INFO, "[CLIENT] retune transceiver with cfo %.3fHz:\n", cfo_hz);
-  LOG(INFO, "[CLIENT] TX LO freq: %lldHz\n",
-      ul_lo + (long long)(cfo_hz * (float)ul_lo / (float)dl_lo));
-  LOG(INFO, "[CLIENT] RX LO freq: %lldHz\n", dl_lo + (long long)cfo_hz);
+  LOG(INFO, "[CLIENT] TX LO freq: %lldHz\n", ul_lo_fixed);
+  LOG(INFO, "[CLIENT] RX LO freq: %lldHz\n", dl_lo_fixed);
   LOG(INFO, "[CLIENT] rxgain adjusted: %d\n", rxgain);
   LOG(INFO, "[CLIENT] txgain adjusted: %d\n", txgain);
   free(rxbuf_time);


### PR DESCRIPTION
We calculate the absolute frequency offset for the DL band. To use this in the UL band we have to scale the offset according to the used UL/DL bands.

We do not compute offset ppm values, since `ofdmframesync_get_cfo()` returns a value in radians, which can be converted to absolute values more easily.